### PR TITLE
keep video if no companion ad

### DIFF
--- a/DACMASDK-Sample/src/main/java/jp/co/dac/sdk/ma/sample/VideoPlayerController.java
+++ b/DACMASDK-Sample/src/main/java/jp/co/dac/sdk/ma/sample/VideoPlayerController.java
@@ -51,6 +51,22 @@ public class VideoPlayerController implements DACMASDKAdErrorEvent.AdErrorListen
         List<DACMASDKCompanionAdSlot> companionAdSlots = new ArrayList<>();
         DACMASDKCompanionAdSlot mediaAdSlot = dacMaSdkFactory.createCompanionAdSlot();
         mediaAdSlot.setContainer(videoPlayerPlayback.getVideoPlayerImage());
+        mediaAdSlot.setAppropriateCompanion(new DACMASDKCompanionAdSlot.AppropriateCompanion() {
+            @Override
+            public boolean isValidRange(int width, int height) {
+                int s, l;
+                if (width >= height) {
+                    s = height;
+                    l = width;
+                } else {
+                    s = width;
+                    l = height;
+                }
+
+                // 3:4, 9:16のようなcompanionを受け入れる
+                return ((float) l) / s  < 2.0;
+            }
+        });
         companionAdSlots.add(mediaAdSlot);
         DACMASDKCompanionAdSlot companionAdSlot = dacMaSdkFactory.createCompanionAdSlot();
         companionAdSlot.setContainer(videoPlayerPlayback.getCompanionView());

--- a/DACMASDK-Sample/src/main/java/jp/co/dac/sdk/ma/sample/VideoPlayerWithAdPlayback.java
+++ b/DACMASDK-Sample/src/main/java/jp/co/dac/sdk/ma/sample/VideoPlayerWithAdPlayback.java
@@ -181,7 +181,11 @@ public class VideoPlayerWithAdPlayback extends FrameLayout {
                             }
                             updateIsAdCompleted(true);
                         }
-                        hideVideoPlayer();
+
+                        if (haveVideoImage()) {
+                            hideVideoPlayer();
+                        }
+
                         break;
                 }
             }
@@ -405,5 +409,13 @@ public class VideoPlayerWithAdPlayback extends FrameLayout {
 
     public ViewGroup getVideoPlayerImage() {
         return (ViewGroup) findViewById(R.id.video_player_image);
+    }
+
+    private boolean haveVideoImage() {
+        ViewGroup videoPlayerImage = getVideoPlayerImage();
+        if (videoPlayerImage == null) {
+            return false;
+        }
+        return videoPlayerImage.getChildCount() != 0;
     }
 }


### PR DESCRIPTION
実装内容
- 3:4, 9:16のみvideoのcompanionとして受け入れる
- companionがなかった時, videoを消さない

