### PR TITLE
not use deprecated method

### DIFF
--- a/DACMediation-Ads-Sample/manual.md
+++ b/DACMediation-Ads-Sample/manual.md
@@ -37,7 +37,7 @@ dependencies {
 
 ```java
 MediationView mediationView = new MediationView(this);
-mediationView.setPlacementId("your dac placement id", "ad height", "ad width");
+mediationView.setPlacementInfo("your dac placement id", "ad height", "ad width");
 ```
 
 
@@ -55,10 +55,11 @@ FacebookRotateHandler fbRotateHandler = new FacebookRotateHandler.Builder(
 mediationView.addRotateHandler(fbRotateHandler);
 ```
 
-次に, 生成したMediationViewを表示したい箇所に`ViewGroup.addView`して下さい.
+次に, 生成したMediationViewを表示したい箇所に`ViewGroup.addView`して, 最後に`MediationView.start`を下さい.
 
 ```java
 view.addView(mediationView);
+mediationView.start();
 ```
 
 これで, 広告が表示されます.

--- a/DACMediation-Ads-Sample/src/main/java/jp/co/dac/sdk/audience/network/sample/MainActivity.java
+++ b/DACMediation-Ads-Sample/src/main/java/jp/co/dac/sdk/audience/network/sample/MainActivity.java
@@ -40,7 +40,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void populateMediationView() {
         mediationView = new MediationView(this);
-        mediationView.setPlacementId(DAC_PLACEMENT_ID, 50, 320);
+        mediationView.setPlacementInfo(DAC_PLACEMENT_ID, 50, 320);
 
         mediationView.setListener(new MediationViewListener() {
             @Override
@@ -72,10 +72,9 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        mediationView
-                .addRotateHandler(fbRotateHandler);
-
+        mediationView.addRotateHandler(fbRotateHandler);
         binding.adViewContainer.addView(mediationView);
+        mediationView.start();
     }
 
     @Override

--- a/DACMediation-Basic-Sample/manual.md
+++ b/DACMediation-Basic-Sample/manual.md
@@ -128,7 +128,8 @@ SDK組み込みサンプル/DACAdsSDK-Sample1/app/src/main/AndroidManifest.xml
 ```java
     MediationView mvBottom;
     mvBottom = (MediationView) findViewById(R.id.mediation_view);
-    mvBottom.setPlacementId(<プレースメントI D > ,<広告表示高さ> ,<広告表示幅> );
+    mvBottom.setPlacementInfo(<プレースメントI D > ,<広告表示高さ> ,<広告表示幅> );
+    mvBottom.start();
 ```
 
 ```java
@@ -161,8 +162,9 @@ import jp.co.dac.dacadssdk.MediationView;
 ```java
     MediationView mvBottom;
     mvBottom = (MediationView) findViewById(R.id.mediation_view);
-    mvBottom.setPlacementId(<プレースメントI D > ,<広告表示高さ> ,<広告表示幅> );
+    mvBottom.setPlacementInfo(<プレースメントI D > ,<広告表示高さ> ,<広告表示幅> );
     rootView.addView(mvTop)
+    mvBottom.start();
 ```
 
 ```java


### PR DESCRIPTION
実装内容

- setPlacementIdの代わりに, setPlacementInfoメソッドを使う

setPlacementIdでは, setと同時に, mediationタスクの開始もしていたので, setPlacementInfoでは, タスクの開始はstart関数に分けました.

```
古いバージョン
mediationView.setPlacementId(hoge, hoge);

新しいバージョン
mediationView.setPlacementInfo(hoge, hoge);
mediationView.start();
```

確認をお願いします.